### PR TITLE
[Fix] delete multiple bookmarks

### DIFF
--- a/src/plugins/lesezeichen/showLesezeichen.vue
+++ b/src/plugins/lesezeichen/showLesezeichen.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-menu v-model="menu" :close-on-content-click="false" :nudge-width="256" offset-y>
+  <v-menu v-model="menu" :close-on-content-click="false" max-width="384" min-width="384" offset-y>
     <template slot="activator">
       <v-badge overlap bottom color="accent" v-if="lesezeichen.liste.length > 0">
         <span slot="badge">{{lesezeichen.liste.length >= 100 ? ':)' : lesezeichen.liste.length}}</span>
@@ -20,7 +20,7 @@
       <v-divider/>
     
       <v-card-text>
-        <v-list >
+        <v-list v-if="lesezeichen.liste.length > 0">
           <v-list-tile v-if="selectedBookmarks.length > 0" inactive>
             <v-list-tile-action @click="selectedBookmarks = []">
               <v-icon>arrow_back</v-icon>
@@ -64,6 +64,15 @@
 
             </v-list-tile>
           </template>
+        </v-list>
+        <v-list v-else three-line>
+          <v-list-tile inactive>
+            <v-list-tile-content>
+              <v-list-tile-title centered>Keine Lesezeichen</v-list-tile-title>
+              <v-list-tile-sub-title>Klicke auf das <v-icon small>star_border</v-icon>-Symbol auf den Details-Seiten um die jeweilige hinzuzufügen.</v-list-tile-sub-title>
+            </v-list-tile-content>
+          </v-list-tile>
+
         </v-list>
       </v-card-text>
     </v-card>

--- a/src/plugins/lesezeichen/showLesezeichen.vue
+++ b/src/plugins/lesezeichen/showLesezeichen.vue
@@ -102,22 +102,21 @@ export default class App extends Vue {
   }
 
   deselect(index: number) {
-    if (this.selectedBookmarks.includes(index)) {
-      const i = this.selectedBookmarks.indexOf(index)
-      this.selectedBookmarks.splice(i)
+    const position = this.selectedBookmarks.indexOf(index)
+
+    if (position > -1) {
+      this.selectedBookmarks.splice(position, 1)
     }
   }
 
   selectAll() {
-    const length = this.lesezeichen.liste.length
-
     this.selectedBookmarks = Array.from(
-      Array(length).keys()
+      this.lesezeichen.liste.keys()
     )
   }
 
   click(index: number) {
-    let bookmark = lesezeichen.liste[index]
+    const bookmark = lesezeichen.liste[index]
 
     xButtonLogic.reset(bookmark.xButton)
     this.menu = false //close menu
@@ -132,11 +131,8 @@ export default class App extends Vue {
   }
 
   unbookmarkSelected() {
-    this.selectedBookmarks.forEach(index =>
-      this.unbookmark(index)
-    )
-
     this.selectedBookmarks = []
+    this.lesezeichen.liste = []
   }
 
   @Watch('menu')


### PR DESCRIPTION
Mir ist aufgefallen, dass wenn man mehrere Lesezeichen gleichzeitig entfernen möchte nur eins entfernt wird. > gefixt

Zusätzlich habe ich noch einen Nachricht, wenn keinen Lesezeichen gesetzt sind eigefügt.